### PR TITLE
Add ACM MM 2025 accepted-papers analysis script and generated reports

### DIFF
--- a/reports/acmmm2025/acmmm2025_accepted_papers_by_category.csv
+++ b/reports/acmmm2025/acmmm2025_accepted_papers_by_category.csv
@@ -1,0 +1,8 @@
+category,count,percentage
+Regular Papers,1250,84.6883
+Datasets,123,8.3333
+Brave New Ideas,44,2.9810
+Demo/Video,30,2.0325
+Open Source Software,14,0.9485
+Interactive Art,12,0.8130
+Doctoral Symposium,3,0.2033

--- a/reports/acmmm2025/acmmm2025_accepted_papers_by_category.svg
+++ b/reports/acmmm2025/acmmm2025_accepted_papers_by_category.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="720" viewBox="0 0 1200 720">
+<rect width="100%" height="100%" fill="white"/>
+<text x="600" y="40" text-anchor="middle" font-size="28" font-family="Arial" font-weight="bold">ACM MM 2025 Accepted Papers by Category</text>
+<text x="600" y="66" text-anchor="middle" font-size="16" font-family="Arial" fill="#444">Source: acmmm2025.org accepted papers pages</text>
+<line x1="110" y1="550" x2="1160" y2="550" stroke="#222" stroke-width="2"/>
+<line x1="110" y1="80" x2="110" y2="550" stroke="#222" stroke-width="2"/>
+<line x1="104" y1="550.0" x2="110" y2="550.0" stroke="#222"/>
+<text x="98" y="555.0" text-anchor="end" font-size="12" font-family="Arial">0</text>
+<line x1="104" y1="456.0" x2="110" y2="456.0" stroke="#222"/>
+<text x="98" y="461.0" text-anchor="end" font-size="12" font-family="Arial">250</text>
+<line x1="110" y1="456.0" x2="1160" y2="456.0" stroke="#ddd" stroke-dasharray="3,4"/>
+<line x1="104" y1="362.0" x2="110" y2="362.0" stroke="#222"/>
+<text x="98" y="367.0" text-anchor="end" font-size="12" font-family="Arial">500</text>
+<line x1="110" y1="362.0" x2="1160" y2="362.0" stroke="#ddd" stroke-dasharray="3,4"/>
+<line x1="104" y1="268.0" x2="110" y2="268.0" stroke="#222"/>
+<text x="98" y="273.0" text-anchor="end" font-size="12" font-family="Arial">750</text>
+<line x1="110" y1="268.0" x2="1160" y2="268.0" stroke="#ddd" stroke-dasharray="3,4"/>
+<line x1="104" y1="174.0" x2="110" y2="174.0" stroke="#222"/>
+<text x="98" y="179.0" text-anchor="end" font-size="12" font-family="Arial">1000</text>
+<line x1="110" y1="174.0" x2="1160" y2="174.0" stroke="#ddd" stroke-dasharray="3,4"/>
+<line x1="104" y1="80.0" x2="110" y2="80.0" stroke="#222"/>
+<text x="98" y="85.0" text-anchor="end" font-size="12" font-family="Arial">1250</text>
+<line x1="110" y1="80.0" x2="1160" y2="80.0" stroke="#ddd" stroke-dasharray="3,4"/>
+<rect x="110.0" y="80.0" width="132.9" height="470.0" fill="#4C78A8"/>
+<text x="176.4" y="70.0" text-anchor="middle" font-size="12" font-family="Arial">1250</text>
+<text x="176.4" y="570" text-anchor="middle" font-size="12" font-family="Arial" transform="rotate(35 176.4 570)">Regular Papers</text>
+<text x="176.4" y="595" text-anchor="middle" font-size="11" fill="#555" font-family="Arial">84.69%</text>
+<rect x="262.9" y="503.8" width="132.9" height="46.2" fill="#F58518"/>
+<text x="329.3" y="493.8" text-anchor="middle" font-size="12" font-family="Arial">123</text>
+<text x="329.3" y="570" text-anchor="middle" font-size="12" font-family="Arial" transform="rotate(35 329.3 570)">Datasets</text>
+<text x="329.3" y="595" text-anchor="middle" font-size="11" fill="#555" font-family="Arial">8.33%</text>
+<rect x="415.7" y="533.5" width="132.9" height="16.5" fill="#E45756"/>
+<text x="482.1" y="523.5" text-anchor="middle" font-size="12" font-family="Arial">44</text>
+<text x="482.1" y="570" text-anchor="middle" font-size="12" font-family="Arial" transform="rotate(35 482.1 570)">Brave New Ideas</text>
+<text x="482.1" y="595" text-anchor="middle" font-size="11" fill="#555" font-family="Arial">2.98%</text>
+<rect x="568.6" y="538.7" width="132.9" height="11.3" fill="#72B7B2"/>
+<text x="635.0" y="528.7" text-anchor="middle" font-size="12" font-family="Arial">30</text>
+<text x="635.0" y="570" text-anchor="middle" font-size="12" font-family="Arial" transform="rotate(35 635.0 570)">Demo/Video</text>
+<text x="635.0" y="595" text-anchor="middle" font-size="11" fill="#555" font-family="Arial">2.03%</text>
+<rect x="721.4" y="544.7" width="132.9" height="5.3" fill="#54A24B"/>
+<text x="787.9" y="534.7" text-anchor="middle" font-size="12" font-family="Arial">14</text>
+<text x="787.9" y="570" text-anchor="middle" font-size="12" font-family="Arial" transform="rotate(35 787.9 570)">Open Source Software</text>
+<text x="787.9" y="595" text-anchor="middle" font-size="11" fill="#555" font-family="Arial">0.95%</text>
+<rect x="874.3" y="545.5" width="132.9" height="4.5" fill="#EECA3B"/>
+<text x="940.7" y="535.5" text-anchor="middle" font-size="12" font-family="Arial">12</text>
+<text x="940.7" y="570" text-anchor="middle" font-size="12" font-family="Arial" transform="rotate(35 940.7 570)">Interactive Art</text>
+<text x="940.7" y="595" text-anchor="middle" font-size="11" fill="#555" font-family="Arial">0.81%</text>
+<rect x="1027.1" y="548.9" width="132.9" height="1.1" fill="#B279A2"/>
+<text x="1093.6" y="538.9" text-anchor="middle" font-size="12" font-family="Arial">3</text>
+<text x="1093.6" y="570" text-anchor="middle" font-size="12" font-family="Arial" transform="rotate(35 1093.6 570)">Doctoral Symposium</text>
+<text x="1093.6" y="595" text-anchor="middle" font-size="11" fill="#555" font-family="Arial">0.20%</text>
+</svg>

--- a/reports/acmmm2025/acmmm2025_accepted_papers_summary.md
+++ b/reports/acmmm2025/acmmm2025_accepted_papers_summary.md
@@ -1,0 +1,15 @@
+# ACM MM 2025 Accepted Papers 分类统计
+
+数据来源：ACM MM 2025 官网各 accepted 页面（通过 WordPress JSON API 抓取并统计每条编号论文）。
+
+| 类别 | 数量 | 占比 |
+|---|---:|---:|
+| Regular Papers | 1250 | 84.69% |
+| Datasets | 123 | 8.33% |
+| Brave New Ideas | 44 | 2.98% |
+| Demo/Video | 30 | 2.03% |
+| Open Source Software | 14 | 0.95% |
+| Interactive Art | 12 | 0.81% |
+| Doctoral Symposium | 3 | 0.20% |
+
+总计：**1476**

--- a/reports/acmmm2025/analyze_acmmm2025.py
+++ b/reports/acmmm2025/analyze_acmmm2025.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+import csv
+import html
+import json
+import re
+import urllib.request
+from pathlib import Path
+
+PAGES = {
+    "Regular Papers": "accepted-regular-papers",
+    "Datasets": "accepted-papers-datasets",
+    "Brave New Ideas": "accepted-papers-brave-new-ideas",
+    "Demo/Video": "accepted-papers-demo-video",
+    "Open Source Software": "accepted-papers-open-source-software",
+    "Doctoral Symposium": "accepted-papers-doctoral-symposium",
+    "Interactive Art": "accepted-papers-interactive-art",
+}
+
+OUT_DIR = Path(__file__).resolve().parent
+CSV_PATH = OUT_DIR / "acmmm2025_accepted_papers_by_category.csv"
+SVG_PATH = OUT_DIR / "acmmm2025_accepted_papers_by_category.svg"
+MD_PATH = OUT_DIR / "acmmm2025_accepted_papers_summary.md"
+
+
+def fetch_page_content(slug: str) -> str:
+    url = f"https://acmmm2025.org/wp-json/wp/v2/pages?slug={slug}"
+    with urllib.request.urlopen(url, timeout=30) as resp:
+        payload = json.loads(resp.read().decode("utf-8"))
+    if not payload:
+        raise RuntimeError(f"Page not found for slug: {slug}")
+    return html.unescape(payload[0]["content"]["rendered"])
+
+
+def count_accepted_entries(rendered_content: str) -> int:
+    return len(re.findall(r"<p>\s*\d+\s*<b>", rendered_content))
+
+
+def build_svg(rows):
+    width, height = 1200, 720
+    margin_left, margin_right, margin_top, margin_bottom = 110, 40, 80, 170
+    chart_w = width - margin_left - margin_right
+    chart_h = height - margin_top - margin_bottom
+
+    max_count = max(r["count"] for r in rows)
+    bar_gap = 20
+    n = len(rows)
+    bar_w = (chart_w - bar_gap * (n - 1)) / n
+
+    colors = ["#4C78A8", "#F58518", "#E45756", "#72B7B2", "#54A24B", "#EECA3B", "#B279A2"]
+
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">',
+        '<rect width="100%" height="100%" fill="white"/>',
+        '<text x="600" y="40" text-anchor="middle" font-size="28" font-family="Arial" font-weight="bold">ACM MM 2025 Accepted Papers by Category</text>',
+        '<text x="600" y="66" text-anchor="middle" font-size="16" font-family="Arial" fill="#444">Source: acmmm2025.org accepted papers pages</text>',
+        f'<line x1="{margin_left}" y1="{margin_top + chart_h}" x2="{margin_left + chart_w}" y2="{margin_top + chart_h}" stroke="#222" stroke-width="2"/>',
+        f'<line x1="{margin_left}" y1="{margin_top}" x2="{margin_left}" y2="{margin_top + chart_h}" stroke="#222" stroke-width="2"/>',
+    ]
+
+    ticks = 5
+    for i in range(ticks + 1):
+        y = margin_top + chart_h - (chart_h * i / ticks)
+        val = int(max_count * i / ticks)
+        parts.append(f'<line x1="{margin_left-6}" y1="{y:.1f}" x2="{margin_left}" y2="{y:.1f}" stroke="#222"/>')
+        parts.append(f'<text x="{margin_left-12}" y="{y+5:.1f}" text-anchor="end" font-size="12" font-family="Arial">{val}</text>')
+        if i > 0:
+            parts.append(f'<line x1="{margin_left}" y1="{y:.1f}" x2="{margin_left+chart_w}" y2="{y:.1f}" stroke="#ddd" stroke-dasharray="3,4"/>')
+
+    for i, row in enumerate(rows):
+        x = margin_left + i * (bar_w + bar_gap)
+        h = chart_h * row["count"] / max_count
+        y = margin_top + chart_h - h
+        color = colors[i % len(colors)]
+
+        parts.append(f'<rect x="{x:.1f}" y="{y:.1f}" width="{bar_w:.1f}" height="{h:.1f}" fill="{color}"/>')
+        parts.append(f'<text x="{x + bar_w/2:.1f}" y="{y - 10:.1f}" text-anchor="middle" font-size="12" font-family="Arial">{row["count"]}</text>')
+        parts.append(f'<text x="{x + bar_w/2:.1f}" y="{margin_top + chart_h + 20}" text-anchor="middle" font-size="12" font-family="Arial" transform="rotate(35 {x + bar_w/2:.1f} {margin_top + chart_h + 20})">{row["category"]}</text>')
+        parts.append(f'<text x="{x + bar_w/2:.1f}" y="{margin_top + chart_h + 45}" text-anchor="middle" font-size="11" fill="#555" font-family="Arial">{row["percentage"]:.2f}%</text>')
+
+    parts.append('</svg>')
+    return "\n".join(parts)
+
+
+def main():
+    rows = []
+    for category, slug in PAGES.items():
+        content = fetch_page_content(slug)
+        rows.append({"category": category, "count": count_accepted_entries(content)})
+
+    rows.sort(key=lambda x: x["count"], reverse=True)
+    total = sum(r["count"] for r in rows)
+    for r in rows:
+        r["percentage"] = (r["count"] / total * 100) if total else 0
+
+    with CSV_PATH.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["category", "count", "percentage"])
+        for r in rows:
+            writer.writerow([r["category"], r["count"], f"{r['percentage']:.4f}"])
+
+    SVG_PATH.write_text(build_svg(rows), encoding="utf-8")
+
+    lines = [
+        "# ACM MM 2025 Accepted Papers 分类统计",
+        "",
+        "数据来源：ACM MM 2025 官网各 accepted 页面（通过 WordPress JSON API 抓取并统计每条编号论文）。",
+        "",
+        "| 类别 | 数量 | 占比 |",
+        "|---|---:|---:|",
+    ]
+    for r in rows:
+        lines.append(f"| {r['category']} | {r['count']} | {r['percentage']:.2f}% |")
+    lines.append("")
+    lines.append(f"总计：**{total}**")
+    MD_PATH.write_text("\n".join(lines), encoding="utf-8")
+
+    print("Wrote:")
+    print(CSV_PATH)
+    print(SVG_PATH)
+    print(MD_PATH)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- Provide an automated way to fetch ACM MM 2025 accepted pages, count accepted entries by category, and produce machine- and human-readable summaries and a visualization. 
- Enable reproducible outputs (CSV, SVG, Markdown) generated from the conference site's WordPress JSON API so the numbers can be consumed by other tooling.

### Description

- Add `reports/acmmm2025/analyze_acmmm2025.py`, which fetches per-category pages via the WordPress JSON API, counts entries using a regex, computes percentages, and sorts categories by count. 
- Implement `build_svg` to render a bar chart SVG and write CSV and Markdown summary files with paths `reports/acmmm2025/acmmm2025_accepted_papers_by_category.csv`, `reports/acmmm2025/acmmm2025_accepted_papers_by_category.svg`, and `reports/acmmm2025/acmmm2025_accepted_papers_summary.md`. 
- Include category mapping in `PAGES`, percentage formatting to four decimals in the CSV, and a readable Markdown table with a total. 
- Add the generated report files under `reports/acmmm2025/` to reflect the output of the script.

### Testing

- Ran the analysis script with `python3 reports/acmmm2025/analyze_acmmm2025.py`, which completed successfully (exit code 0) and wrote `acmmm2025_accepted_papers_by_category.csv`, `acmmm2025_accepted_papers_by_category.svg`, and `acmmm2025_accepted_papers_summary.md` to `reports/acmmm2025/`.
- Verified that the generated CSV contains category counts and percentage values and that the Markdown summary table matches the CSV totals.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5a111e2fc832e820257e09c87ba94)