### PR TITLE
Add ACM MM 2025 analysis script and generated reports (CSV/MD/SVG)

### DIFF
--- a/reports/acmmm2025/acmmm2025_accepted_papers_by_category.csv
+++ b/reports/acmmm2025/acmmm2025_accepted_papers_by_category.csv
@@ -1,0 +1,8 @@
+category,count,percentage
+Regular Papers,1250,84.6883
+Datasets,123,8.3333
+Brave New Ideas,44,2.9810
+Demo/Video,30,2.0325
+Open Source Software,14,0.9485
+Interactive Art,12,0.8130
+Doctoral Symposium,3,0.2033

--- a/reports/acmmm2025/acmmm2025_accepted_papers_by_category.svg
+++ b/reports/acmmm2025/acmmm2025_accepted_papers_by_category.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="720" viewBox="0 0 1200 720">
+<rect width="100%" height="100%" fill="white"/>
+<text x="600" y="40" text-anchor="middle" font-size="28" font-family="Arial" font-weight="bold">ACM MM 2025 Accepted Papers by Category</text>
+<text x="600" y="66" text-anchor="middle" font-size="16" font-family="Arial" fill="#444">Source: acmmm2025.org accepted papers pages</text>
+<line x1="110" y1="550" x2="1160" y2="550" stroke="#222" stroke-width="2"/>
+<line x1="110" y1="80" x2="110" y2="550" stroke="#222" stroke-width="2"/>
+<line x1="104" y1="550.0" x2="110" y2="550.0" stroke="#222"/>
+<text x="98" y="555.0" text-anchor="end" font-size="12" font-family="Arial">0</text>
+<line x1="104" y1="456.0" x2="110" y2="456.0" stroke="#222"/>
+<text x="98" y="461.0" text-anchor="end" font-size="12" font-family="Arial">250</text>
+<line x1="110" y1="456.0" x2="1160" y2="456.0" stroke="#ddd" stroke-dasharray="3,4"/>
+<line x1="104" y1="362.0" x2="110" y2="362.0" stroke="#222"/>
+<text x="98" y="367.0" text-anchor="end" font-size="12" font-family="Arial">500</text>
+<line x1="110" y1="362.0" x2="1160" y2="362.0" stroke="#ddd" stroke-dasharray="3,4"/>
+<line x1="104" y1="268.0" x2="110" y2="268.0" stroke="#222"/>
+<text x="98" y="273.0" text-anchor="end" font-size="12" font-family="Arial">750</text>
+<line x1="110" y1="268.0" x2="1160" y2="268.0" stroke="#ddd" stroke-dasharray="3,4"/>
+<line x1="104" y1="174.0" x2="110" y2="174.0" stroke="#222"/>
+<text x="98" y="179.0" text-anchor="end" font-size="12" font-family="Arial">1000</text>
+<line x1="110" y1="174.0" x2="1160" y2="174.0" stroke="#ddd" stroke-dasharray="3,4"/>
+<line x1="104" y1="80.0" x2="110" y2="80.0" stroke="#222"/>
+<text x="98" y="85.0" text-anchor="end" font-size="12" font-family="Arial">1250</text>
+<line x1="110" y1="80.0" x2="1160" y2="80.0" stroke="#ddd" stroke-dasharray="3,4"/>
+<rect x="110.0" y="80.0" width="132.9" height="470.0" fill="#4C78A8"/>
+<text x="176.4" y="70.0" text-anchor="middle" font-size="12" font-family="Arial">1250</text>
+<text x="176.4" y="570" text-anchor="middle" font-size="12" font-family="Arial" transform="rotate(35 176.4 570)">Regular Papers</text>
+<text x="176.4" y="595" text-anchor="middle" font-size="11" fill="#555" font-family="Arial">84.69%</text>
+<rect x="262.9" y="503.8" width="132.9" height="46.2" fill="#F58518"/>
+<text x="329.3" y="493.8" text-anchor="middle" font-size="12" font-family="Arial">123</text>
+<text x="329.3" y="570" text-anchor="middle" font-size="12" font-family="Arial" transform="rotate(35 329.3 570)">Datasets</text>
+<text x="329.3" y="595" text-anchor="middle" font-size="11" fill="#555" font-family="Arial">8.33%</text>
+<rect x="415.7" y="533.5" width="132.9" height="16.5" fill="#E45756"/>
+<text x="482.1" y="523.5" text-anchor="middle" font-size="12" font-family="Arial">44</text>
+<text x="482.1" y="570" text-anchor="middle" font-size="12" font-family="Arial" transform="rotate(35 482.1 570)">Brave New Ideas</text>
+<text x="482.1" y="595" text-anchor="middle" font-size="11" fill="#555" font-family="Arial">2.98%</text>
+<rect x="568.6" y="538.7" width="132.9" height="11.3" fill="#72B7B2"/>
+<text x="635.0" y="528.7" text-anchor="middle" font-size="12" font-family="Arial">30</text>
+<text x="635.0" y="570" text-anchor="middle" font-size="12" font-family="Arial" transform="rotate(35 635.0 570)">Demo/Video</text>
+<text x="635.0" y="595" text-anchor="middle" font-size="11" fill="#555" font-family="Arial">2.03%</text>
+<rect x="721.4" y="544.7" width="132.9" height="5.3" fill="#54A24B"/>
+<text x="787.9" y="534.7" text-anchor="middle" font-size="12" font-family="Arial">14</text>
+<text x="787.9" y="570" text-anchor="middle" font-size="12" font-family="Arial" transform="rotate(35 787.9 570)">Open Source Software</text>
+<text x="787.9" y="595" text-anchor="middle" font-size="11" fill="#555" font-family="Arial">0.95%</text>
+<rect x="874.3" y="545.5" width="132.9" height="4.5" fill="#EECA3B"/>
+<text x="940.7" y="535.5" text-anchor="middle" font-size="12" font-family="Arial">12</text>
+<text x="940.7" y="570" text-anchor="middle" font-size="12" font-family="Arial" transform="rotate(35 940.7 570)">Interactive Art</text>
+<text x="940.7" y="595" text-anchor="middle" font-size="11" fill="#555" font-family="Arial">0.81%</text>
+<rect x="1027.1" y="548.9" width="132.9" height="1.1" fill="#B279A2"/>
+<text x="1093.6" y="538.9" text-anchor="middle" font-size="12" font-family="Arial">3</text>
+<text x="1093.6" y="570" text-anchor="middle" font-size="12" font-family="Arial" transform="rotate(35 1093.6 570)">Doctoral Symposium</text>
+<text x="1093.6" y="595" text-anchor="middle" font-size="11" fill="#555" font-family="Arial">0.20%</text>
+</svg>

--- a/reports/acmmm2025/acmmm2025_accepted_papers_summary.md
+++ b/reports/acmmm2025/acmmm2025_accepted_papers_summary.md
@@ -1,0 +1,15 @@
+# ACM MM 2025 Accepted Papers 分类统计
+
+数据来源：ACM MM 2025 官网各 accepted 页面（通过 WordPress JSON API 抓取并统计每条编号论文）。
+
+| 类别 | 数量 | 占比 |
+|---|---:|---:|
+| Regular Papers | 1250 | 84.69% |
+| Datasets | 123 | 8.33% |
+| Brave New Ideas | 44 | 2.98% |
+| Demo/Video | 30 | 2.03% |
+| Open Source Software | 14 | 0.95% |
+| Interactive Art | 12 | 0.81% |
+| Doctoral Symposium | 3 | 0.20% |
+
+总计：**1476**

--- a/reports/acmmm2025/acmmm2025_direction_top_method_type.md
+++ b/reports/acmmm2025/acmmm2025_direction_top_method_type.md
@@ -1,0 +1,99 @@
+# ACM MM 2025 Regular Papers: 每个方向中占比最高的方法类型（基于标题关键词）
+
+说明：先按 `analyze_acmmm2025.py` 的方向规则分类，再在每个方向内按方法关键词统计；若标题未出现明显方法词，归为 `General/Unspecified`。
+
+| 方向 | Top 方法类型 | 数量 | 方向内占比 |
+|---|---|---:|---:|
+| Generation / Diffusion / AIGC | General/Unspecified | 127 | 50.40% |
+| Other / General Multimedia | General/Unspecified | 211 | 85.08% |
+| Foundation Models / LLM / MLLM | LLM/MLLM | 134 | 61.19% |
+| Vision-Language / Multimodal Understanding | General/Unspecified | 105 | 77.21% |
+| Video Understanding / Temporal Modeling | General/Unspecified | 104 | 78.79% |
+| Retrieval / Recommendation / Search | General/Unspecified | 32 | 43.84% |
+| 3D / Embodied / Spatial | General/Unspecified | 52 | 83.87% |
+| Security / Privacy / Watermark | General/Unspecified | 32 | 84.21% |
+| Efficiency / Optimization / Compression | General/Unspecified | 19 | 65.52% |
+| Graph / Knowledge / Causality | Graph Neural Network | 16 | 55.17% |
+| Audio / Speech / Music | General/Unspecified | 16 | 94.12% |
+| Medical / Bio / Healthcare | General/Unspecified | 10 | 66.67% |
+
+## 各方向方法类型详细计数（Top 5）
+
+### Generation / Diffusion / AIGC
+- General/Unspecified: 127 (50.40%)
+- Diffusion: 89 (35.32%)
+- Transformer: 8 (3.17%)
+- Retrieval-Augmented: 8 (3.17%)
+- Graph Neural Network: 8 (3.17%)
+
+### Other / General Multimedia
+- General/Unspecified: 211 (85.08%)
+- Contrastive Learning: 14 (5.65%)
+- Transformer: 8 (3.23%)
+- Reinforcement Learning: 8 (3.23%)
+- Adapter/LoRA/Fine-tuning: 6 (2.42%)
+
+### Foundation Models / LLM / MLLM
+- LLM/MLLM: 134 (61.19%)
+- Prompt/Instruction Tuning: 43 (19.63%)
+- General/Unspecified: 18 (8.22%)
+- Transformer: 14 (6.39%)
+- Reinforcement Learning: 3 (1.37%)
+
+### Vision-Language / Multimodal Understanding
+- General/Unspecified: 105 (77.21%)
+- Graph Neural Network: 9 (6.62%)
+- Contrastive Learning: 7 (5.15%)
+- Transformer: 5 (3.68%)
+- Reinforcement Learning: 4 (2.94%)
+
+### Video Understanding / Temporal Modeling
+- General/Unspecified: 104 (78.79%)
+- Transformer: 11 (8.33%)
+- Graph Neural Network: 8 (6.06%)
+- Reinforcement Learning: 5 (3.79%)
+- Contrastive Learning: 2 (1.52%)
+
+### Retrieval / Recommendation / Search
+- General/Unspecified: 32 (43.84%)
+- Retrieval-Augmented: 27 (36.99%)
+- Graph Neural Network: 4 (5.48%)
+- Contrastive Learning: 4 (5.48%)
+- Transformer: 3 (4.11%)
+
+### 3D / Embodied / Spatial
+- General/Unspecified: 52 (83.87%)
+- Graph Neural Network: 3 (4.84%)
+- Contrastive Learning: 2 (3.23%)
+- Transformer: 2 (3.23%)
+- Optimization (Zero-order etc.): 1 (1.61%)
+
+### Security / Privacy / Watermark
+- General/Unspecified: 32 (84.21%)
+- Adapter/LoRA/Fine-tuning: 1 (2.63%)
+- Contrastive Learning: 1 (2.63%)
+- Graph Neural Network: 1 (2.63%)
+- Retrieval-Augmented: 1 (2.63%)
+
+### Efficiency / Optimization / Compression
+- General/Unspecified: 19 (65.52%)
+- Graph Neural Network: 3 (10.34%)
+- Transformer: 3 (10.34%)
+- Optimization (Zero-order etc.): 3 (10.34%)
+- Contrastive Learning: 1 (3.45%)
+
+### Graph / Knowledge / Causality
+- Graph Neural Network: 16 (55.17%)
+- General/Unspecified: 6 (20.69%)
+- Contrastive Learning: 4 (13.79%)
+- Transformer: 3 (10.34%)
+
+### Audio / Speech / Music
+- General/Unspecified: 16 (94.12%)
+- Transformer: 1 (5.88%)
+
+### Medical / Bio / Healthcare
+- General/Unspecified: 10 (66.67%)
+- Transformer: 3 (20.00%)
+- Reinforcement Learning: 1 (6.67%)
+- Retrieval-Augmented: 1 (6.67%)

--- a/reports/acmmm2025/acmmm2025_regular_papers_by_direction.csv
+++ b/reports/acmmm2025/acmmm2025_regular_papers_by_direction.csv
@@ -1,0 +1,13 @@
+direction,count,percentage
+Generation / Diffusion / AIGC,252,20.1600
+Other / General Multimedia,248,19.8400
+Foundation Models / LLM / MLLM,219,17.5200
+Vision-Language / Multimodal Understanding,136,10.8800
+Video Understanding / Temporal Modeling,132,10.5600
+Retrieval / Recommendation / Search,73,5.8400
+3D / Embodied / Spatial,62,4.9600
+Security / Privacy / Watermark,38,3.0400
+Efficiency / Optimization / Compression,29,2.3200
+Graph / Knowledge / Causality,29,2.3200
+Audio / Speech / Music,17,1.3600
+Medical / Bio / Healthcare,15,1.2000

--- a/reports/acmmm2025/acmmm2025_regular_papers_by_direction.md
+++ b/reports/acmmm2025/acmmm2025_regular_papers_by_direction.md
@@ -1,0 +1,20 @@
+# ACM MM 2025 Regular Papers 方向分类统计（基于标题关键词）
+
+说明：这是**启发式关键词分类**，用于快速观察方向占比，不等同于官方 track 划分。
+
+| 方向 | 数量 | 占比 |
+|---|---:|---:|
+| Generation / Diffusion / AIGC | 252 | 20.16% |
+| Other / General Multimedia | 248 | 19.84% |
+| Foundation Models / LLM / MLLM | 219 | 17.52% |
+| Vision-Language / Multimodal Understanding | 136 | 10.88% |
+| Video Understanding / Temporal Modeling | 132 | 10.56% |
+| Retrieval / Recommendation / Search | 73 | 5.84% |
+| 3D / Embodied / Spatial | 62 | 4.96% |
+| Security / Privacy / Watermark | 38 | 3.04% |
+| Efficiency / Optimization / Compression | 29 | 2.32% |
+| Graph / Knowledge / Causality | 29 | 2.32% |
+| Audio / Speech / Music | 17 | 1.36% |
+| Medical / Bio / Healthcare | 15 | 1.20% |
+
+Regular Papers 总计：**1250**

--- a/reports/acmmm2025/acmmm2025_regular_papers_by_direction.svg
+++ b/reports/acmmm2025/acmmm2025_regular_papers_by_direction.svg
@@ -1,0 +1,72 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1300" height="760" viewBox="0 0 1300 760">
+<rect width="100%" height="100%" fill="white"/>
+<text x="650" y="42" text-anchor="middle" font-size="28" font-family="Arial" font-weight="bold">ACM MM 2025 Regular Papers by Research Direction</text>
+<text x="650" y="70" text-anchor="middle" font-size="16" font-family="Arial" fill="#444">Keyword-based classification from accepted regular paper titles</text>
+<line x1="120" y1="540" x2="1250" y2="540" stroke="#222" stroke-width="2"/>
+<line x1="120" y1="90" x2="120" y2="540" stroke="#222" stroke-width="2"/>
+<line x1="114" y1="540.0" x2="120" y2="540.0" stroke="#222"/>
+<text x="108" y="545.0" text-anchor="end" font-size="12" font-family="Arial">0</text>
+<line x1="114" y1="450.0" x2="120" y2="450.0" stroke="#222"/>
+<text x="108" y="455.0" text-anchor="end" font-size="12" font-family="Arial">50</text>
+<line x1="120" y1="450.0" x2="1250" y2="450.0" stroke="#ddd" stroke-dasharray="3,4"/>
+<line x1="114" y1="360.0" x2="120" y2="360.0" stroke="#222"/>
+<text x="108" y="365.0" text-anchor="end" font-size="12" font-family="Arial">100</text>
+<line x1="120" y1="360.0" x2="1250" y2="360.0" stroke="#ddd" stroke-dasharray="3,4"/>
+<line x1="114" y1="270.0" x2="120" y2="270.0" stroke="#222"/>
+<text x="108" y="275.0" text-anchor="end" font-size="12" font-family="Arial">151</text>
+<line x1="120" y1="270.0" x2="1250" y2="270.0" stroke="#ddd" stroke-dasharray="3,4"/>
+<line x1="114" y1="180.0" x2="120" y2="180.0" stroke="#222"/>
+<text x="108" y="185.0" text-anchor="end" font-size="12" font-family="Arial">201</text>
+<line x1="120" y1="180.0" x2="1250" y2="180.0" stroke="#ddd" stroke-dasharray="3,4"/>
+<line x1="114" y1="90.0" x2="120" y2="90.0" stroke="#222"/>
+<text x="108" y="95.0" text-anchor="end" font-size="12" font-family="Arial">252</text>
+<line x1="120" y1="90.0" x2="1250" y2="90.0" stroke="#ddd" stroke-dasharray="3,4"/>
+<rect x="120.0" y="90.0" width="81.3" height="450.0" fill="#4E79A7"/>
+<text x="160.7" y="82.0" text-anchor="middle" font-size="12" font-family="Arial">252</text>
+<text x="160.7" y="560" text-anchor="middle" font-size="11" font-family="Arial" transform="rotate(33 160.7 560)">Generation / Diffusion / AIGC</text>
+<text x="160.7" y="586" text-anchor="middle" font-size="10" fill="#555" font-family="Arial">20.16%</text>
+<rect x="215.3" y="97.1" width="81.3" height="442.9" fill="#F28E2B"/>
+<text x="256.0" y="89.1" text-anchor="middle" font-size="12" font-family="Arial">248</text>
+<text x="256.0" y="560" text-anchor="middle" font-size="11" font-family="Arial" transform="rotate(33 256.0 560)">Other / General Multimedia</text>
+<text x="256.0" y="586" text-anchor="middle" font-size="10" fill="#555" font-family="Arial">19.84%</text>
+<rect x="310.7" y="148.9" width="81.3" height="391.1" fill="#E15759"/>
+<text x="351.3" y="140.9" text-anchor="middle" font-size="12" font-family="Arial">219</text>
+<text x="351.3" y="560" text-anchor="middle" font-size="11" font-family="Arial" transform="rotate(33 351.3 560)">Foundation Models / LLM / MLLM</text>
+<text x="351.3" y="586" text-anchor="middle" font-size="10" fill="#555" font-family="Arial">17.52%</text>
+<rect x="406.0" y="297.1" width="81.3" height="242.9" fill="#76B7B2"/>
+<text x="446.7" y="289.1" text-anchor="middle" font-size="12" font-family="Arial">136</text>
+<text x="446.7" y="560" text-anchor="middle" font-size="11" font-family="Arial" transform="rotate(33 446.7 560)">Vision-Language / Multimodal Understanding</text>
+<text x="446.7" y="586" text-anchor="middle" font-size="10" fill="#555" font-family="Arial">10.88%</text>
+<rect x="501.3" y="304.3" width="81.3" height="235.7" fill="#59A14F"/>
+<text x="542.0" y="296.3" text-anchor="middle" font-size="12" font-family="Arial">132</text>
+<text x="542.0" y="560" text-anchor="middle" font-size="11" font-family="Arial" transform="rotate(33 542.0 560)">Video Understanding / Temporal Modeling</text>
+<text x="542.0" y="586" text-anchor="middle" font-size="10" fill="#555" font-family="Arial">10.56%</text>
+<rect x="596.7" y="409.6" width="81.3" height="130.4" fill="#EDC948"/>
+<text x="637.3" y="401.6" text-anchor="middle" font-size="12" font-family="Arial">73</text>
+<text x="637.3" y="560" text-anchor="middle" font-size="11" font-family="Arial" transform="rotate(33 637.3 560)">Retrieval / Recommendation / Search</text>
+<text x="637.3" y="586" text-anchor="middle" font-size="10" fill="#555" font-family="Arial">5.84%</text>
+<rect x="692.0" y="429.3" width="81.3" height="110.7" fill="#B07AA1"/>
+<text x="732.7" y="421.3" text-anchor="middle" font-size="12" font-family="Arial">62</text>
+<text x="732.7" y="560" text-anchor="middle" font-size="11" font-family="Arial" transform="rotate(33 732.7 560)">3D / Embodied / Spatial</text>
+<text x="732.7" y="586" text-anchor="middle" font-size="10" fill="#555" font-family="Arial">4.96%</text>
+<rect x="787.3" y="472.1" width="81.3" height="67.9" fill="#FF9DA7"/>
+<text x="828.0" y="464.1" text-anchor="middle" font-size="12" font-family="Arial">38</text>
+<text x="828.0" y="560" text-anchor="middle" font-size="11" font-family="Arial" transform="rotate(33 828.0 560)">Security / Privacy / Watermark</text>
+<text x="828.0" y="586" text-anchor="middle" font-size="10" fill="#555" font-family="Arial">3.04%</text>
+<rect x="882.7" y="488.2" width="81.3" height="51.8" fill="#9C755F"/>
+<text x="923.3" y="480.2" text-anchor="middle" font-size="12" font-family="Arial">29</text>
+<text x="923.3" y="560" text-anchor="middle" font-size="11" font-family="Arial" transform="rotate(33 923.3 560)">Efficiency / Optimization / Compression</text>
+<text x="923.3" y="586" text-anchor="middle" font-size="10" fill="#555" font-family="Arial">2.32%</text>
+<rect x="978.0" y="488.2" width="81.3" height="51.8" fill="#BAB0AC"/>
+<text x="1018.7" y="480.2" text-anchor="middle" font-size="12" font-family="Arial">29</text>
+<text x="1018.7" y="560" text-anchor="middle" font-size="11" font-family="Arial" transform="rotate(33 1018.7 560)">Graph / Knowledge / Causality</text>
+<text x="1018.7" y="586" text-anchor="middle" font-size="10" fill="#555" font-family="Arial">2.32%</text>
+<rect x="1073.3" y="509.6" width="81.3" height="30.4" fill="#8CD17D"/>
+<text x="1114.0" y="501.6" text-anchor="middle" font-size="12" font-family="Arial">17</text>
+<text x="1114.0" y="560" text-anchor="middle" font-size="11" font-family="Arial" transform="rotate(33 1114.0 560)">Audio / Speech / Music</text>
+<text x="1114.0" y="586" text-anchor="middle" font-size="10" fill="#555" font-family="Arial">1.36%</text>
+<rect x="1168.7" y="513.2" width="81.3" height="26.8" fill="#499894"/>
+<text x="1209.3" y="505.2" text-anchor="middle" font-size="12" font-family="Arial">15</text>
+<text x="1209.3" y="560" text-anchor="middle" font-size="11" font-family="Arial" transform="rotate(33 1209.3 560)">Medical / Bio / Healthcare</text>
+<text x="1209.3" y="586" text-anchor="middle" font-size="10" fill="#555" font-family="Arial">1.20%</text>
+</svg>

--- a/reports/acmmm2025/analyze_acmmm2025.py
+++ b/reports/acmmm2025/analyze_acmmm2025.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Analyze ACM MM 2025 accepted regular papers by research directions.
+
+This script fetches the accepted regular papers page from the ACM MM 2025
+WordPress API, extracts paper titles, applies a keyword-based direction
+classifier, and writes CSV/Markdown/SVG outputs.
+"""
+
+import csv
+import html
+import json
+import re
+import urllib.request
+from collections import defaultdict
+from pathlib import Path
+
+REGULAR_PAPERS_SLUG = "accepted-regular-papers"
+
+# Priority order matters: the first matching direction is assigned.
+DIRECTION_KEYWORDS = [
+    (
+        "Foundation Models / LLM / MLLM",
+        [
+            "llm", "mllm", "vlm", "large language model", "foundation model",
+            "language model", "multimodal large", "gpt", "diffusion transformer",
+            "instruction tuning", "prompt", "in-context", "agent"
+        ],
+    ),
+    (
+        "Generation / Diffusion / AIGC",
+        [
+            "diffusion", "generation", "generative", "text-to-image", "image-to-image",
+            "video generation", "synthesis", "gan", "edit", "editing", "stylization",
+            "inpainting", "outpainting", "3dgs", "gaussian splatting"
+        ],
+    ),
+    (
+        "Retrieval / Recommendation / Search",
+        [
+            "retrieval", "recommendation", "recommender", "search", "ranking",
+            "matching", "query", "rerank", "cross-modal retrieval"
+        ],
+    ),
+    (
+        "Vision-Language / Multimodal Understanding",
+        [
+            "vision-language", "multimodal", "image caption", "visual question answering",
+            "vqa", "cross-modal", "grounding", "alignment", "reasoning"
+        ],
+    ),
+    (
+        "Video Understanding / Temporal Modeling",
+        [
+            "video", "temporal", "action", "event", "trajectory", "tracking", "streaming"
+        ],
+    ),
+    (
+        "Audio / Speech / Music",
+        [
+            "audio", "speech", "music", "acoustic", "sound", "voice", "singing"
+        ],
+    ),
+    (
+        "3D / Embodied / Spatial",
+        [
+            "3d", "neural radiance", "nerf", "point cloud", "mesh", "embodied",
+            "spatial", "scene", "depth"
+        ],
+    ),
+    (
+        "Medical / Bio / Healthcare",
+        [
+            "medical", "clinical", "health", "healthcare", "bio", "biomedical", "disease"
+        ],
+    ),
+    (
+        "Security / Privacy / Watermark",
+        [
+            "security", "privacy", "watermark", "backdoor", "adversarial", "robust",
+            "defense", "attack", "forensics"
+        ],
+    ),
+    (
+        "Efficiency / Optimization / Compression",
+        [
+            "optimization", "zero-order", "zeroth-order", "efficient", "compression",
+            "quantization", "pruning", "distillation", "acceleration", "low-rank"
+        ],
+    ),
+    (
+        "Graph / Knowledge / Causality",
+        [
+            "graph", "knowledge", "causal", "causality", "ontology", "knowledge graph"
+        ],
+    ),
+]
+
+OUT_DIR = Path(__file__).resolve().parent
+CSV_PATH = OUT_DIR / "acmmm2025_regular_papers_by_direction.csv"
+SVG_PATH = OUT_DIR / "acmmm2025_regular_papers_by_direction.svg"
+MD_PATH = OUT_DIR / "acmmm2025_regular_papers_by_direction.md"
+
+
+def fetch_page_content(slug: str) -> str:
+    url = f"https://acmmm2025.org/wp-json/wp/v2/pages?slug={slug}"
+    with urllib.request.urlopen(url, timeout=30) as resp:
+        payload = json.loads(resp.read().decode("utf-8"))
+    if not payload:
+        raise RuntimeError(f"Page not found for slug: {slug}")
+    return html.unescape(payload[0]["content"]["rendered"])
+
+
+def extract_titles(rendered_content: str) -> list[str]:
+    # Format in source: <p>1 <b>Title</b><br /> Authors...</p>
+    raw_titles = re.findall(r"<p>\s*\d+\s*<b>(.*?)</b>\s*<br\s*/?>", rendered_content, flags=re.I | re.S)
+    clean = [re.sub(r"\s+", " ", re.sub(r"<.*?>", "", t)).strip() for t in raw_titles]
+    return [t for t in clean if t]
+
+
+def classify_title(title: str) -> str:
+    t = title.lower()
+    for direction, keywords in DIRECTION_KEYWORDS:
+        if any(k in t for k in keywords):
+            return direction
+    return "Other / General Multimedia"
+
+
+def build_svg(rows):
+    width, height = 1300, 760
+    margin_left, margin_right, margin_top, margin_bottom = 120, 50, 90, 220
+    chart_w = width - margin_left - margin_right
+    chart_h = height - margin_top - margin_bottom
+    max_count = max(r["count"] for r in rows)
+
+    n = len(rows)
+    bar_gap = 14
+    bar_w = (chart_w - bar_gap * (n - 1)) / n
+
+    colors = ["#4E79A7", "#F28E2B", "#E15759", "#76B7B2", "#59A14F", "#EDC948", "#B07AA1", "#FF9DA7", "#9C755F", "#BAB0AC", "#8CD17D", "#499894"]
+
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">',
+        '<rect width="100%" height="100%" fill="white"/>',
+        '<text x="650" y="42" text-anchor="middle" font-size="28" font-family="Arial" font-weight="bold">ACM MM 2025 Regular Papers by Research Direction</text>',
+        '<text x="650" y="70" text-anchor="middle" font-size="16" font-family="Arial" fill="#444">Keyword-based classification from accepted regular paper titles</text>',
+        f'<line x1="{margin_left}" y1="{margin_top+chart_h}" x2="{margin_left+chart_w}" y2="{margin_top+chart_h}" stroke="#222" stroke-width="2"/>',
+        f'<line x1="{margin_left}" y1="{margin_top}" x2="{margin_left}" y2="{margin_top+chart_h}" stroke="#222" stroke-width="2"/>'
+    ]
+
+    for i in range(0, 6):
+        y = margin_top + chart_h - chart_h * i / 5
+        v = int(max_count * i / 5)
+        parts.append(f'<line x1="{margin_left-6}" y1="{y:.1f}" x2="{margin_left}" y2="{y:.1f}" stroke="#222"/>')
+        parts.append(f'<text x="{margin_left-12}" y="{y+5:.1f}" text-anchor="end" font-size="12" font-family="Arial">{v}</text>')
+        if i:
+            parts.append(f'<line x1="{margin_left}" y1="{y:.1f}" x2="{margin_left+chart_w}" y2="{y:.1f}" stroke="#ddd" stroke-dasharray="3,4"/>')
+
+    for i, r in enumerate(rows):
+        x = margin_left + i * (bar_w + bar_gap)
+        h = (r["count"] / max_count) * chart_h
+        y = margin_top + chart_h - h
+        c = colors[i % len(colors)]
+        parts.append(f'<rect x="{x:.1f}" y="{y:.1f}" width="{bar_w:.1f}" height="{h:.1f}" fill="{c}"/>')
+        parts.append(f'<text x="{x+bar_w/2:.1f}" y="{y-8:.1f}" text-anchor="middle" font-size="12" font-family="Arial">{r["count"]}</text>')
+        parts.append(f'<text x="{x+bar_w/2:.1f}" y="{margin_top+chart_h+20}" text-anchor="middle" font-size="11" font-family="Arial" transform="rotate(33 {x+bar_w/2:.1f} {margin_top+chart_h+20})">{r["direction"]}</text>')
+        parts.append(f'<text x="{x+bar_w/2:.1f}" y="{margin_top+chart_h+46}" text-anchor="middle" font-size="10" fill="#555" font-family="Arial">{r["percentage"]:.2f}%</text>')
+
+    parts.append('</svg>')
+    return "\n".join(parts)
+
+
+def main():
+    content = fetch_page_content(REGULAR_PAPERS_SLUG)
+    titles = extract_titles(content)
+
+    counts = defaultdict(int)
+    for t in titles:
+        counts[classify_title(t)] += 1
+
+    total = len(titles)
+    rows = [
+        {"direction": k, "count": v, "percentage": (v / total * 100 if total else 0)}
+        for k, v in counts.items()
+    ]
+    rows.sort(key=lambda r: r["count"], reverse=True)
+
+    with CSV_PATH.open("w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["direction", "count", "percentage"])
+        for r in rows:
+            w.writerow([r["direction"], r["count"], f"{r['percentage']:.4f}"])
+
+    SVG_PATH.write_text(build_svg(rows), encoding="utf-8")
+
+    lines = [
+        "# ACM MM 2025 Regular Papers 方向分类统计（基于标题关键词）",
+        "",
+        "说明：这是**启发式关键词分类**，用于快速观察方向占比，不等同于官方 track 划分。",
+        "",
+        "| 方向 | 数量 | 占比 |",
+        "|---|---:|---:|",
+    ]
+    for r in rows:
+        lines.append(f"| {r['direction']} | {r['count']} | {r['percentage']:.2f}% |")
+    lines += ["", f"Regular Papers 总计：**{total}**"]
+    MD_PATH.write_text("\n".join(lines), encoding="utf-8")
+
+    print(f"Total regular papers extracted: {total}")
+    print(CSV_PATH)
+    print(SVG_PATH)
+    print(MD_PATH)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a quick, reproducible analysis of ACM MM 2025 accepted papers by category and by research direction using a keyword-based heuristic applied to paper titles.
- Produce human- and machine-readable artifacts (CSV, Markdown summary, and SVG charts) to make the acceptance breakdowns easy to inspect and share.

### Description
- Add `reports/acmmm2025/analyze_acmmm2025.py`, a script that fetches the WordPress page for accepted regular papers, extracts titles via `extract_titles`, classifies titles using the prioritized `DIRECTION_KEYWORDS` list in `classify_title`, and writes CSV/Markdown/SVG outputs.
- Generate direction-level outputs `reports/acmmm2025/acmmm2025_regular_papers_by_direction.csv`, `reports/acmmm2025/acmmm2025_regular_papers_by_direction.md`, and `reports/acmmm2025/acmmm2025_regular_papers_by_direction.svg` produced by the script and committed here.
- Add category-level reports `reports/acmmm2025/acmmm2025_accepted_papers_by_category.csv`, `reports/acmmm2025/acmmm2025_accepted_papers_by_category.svg`, and `reports/acmmm2025/acmmm2025_accepted_papers_summary.md` summarizing all accepted items and totals.
- Implement `build_svg` to render a simple bar chart SVG for the direction breakdown and format percentages in the CSV/Markdown outputs.

### Testing
- Executed the analysis with `python3 reports/acmmm2025/analyze_acmmm2025.py`, which completed with exit code 0 and produced the CSV/MD/SVG files included in this PR.
- Verified that the generated CSVs contain the expected headers and that the totals in the committed Markdown summaries match the produced data (Regular Papers total `1250` and overall total `1476`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5a111e2fc832e820257e09c87ba94)